### PR TITLE
Mistake in parameter name

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -8,5 +8,5 @@ postgres:
   database_name: appdb
   username: appuser
   password: App1970#
-  useSSL: false
+  use_ssl: false
   time_zone: UTC


### PR DESCRIPTION
In [postgres config](https://github.com/dukefirehawk/boilerplates/blob/b5fea5806d1eec5cf46d88bd3ba8d4cf9a5b2f34/config/default.yaml#L11) ssl requirement is set with key `useSSL`, but in [connectToPostgres](https://github.com/dukefirehawk/boilerplates/blob/b5fea5806d1eec5cf46d88bd3ba8d4cf9a5b2f34/lib/src/config/plugins/orm.dart#L33) it is parsed as `use_ssl`. As a result, the value is not parsed and therefore the solution does not work.

Other parameters in flutter in general and this config in particular use snake_case, so I suggest to rename the parameter according to this style.

I think this small change will make this example repository less confusing.